### PR TITLE
fix: recipe title styles specificity

### DIFF
--- a/src/pages/[lang]/recipe/[name].astro
+++ b/src/pages/[lang]/recipe/[name].astro
@@ -43,7 +43,7 @@ import RecipeMetaData from "../../../components/RecipeMetaData.astro";
 </Layout>
 
 <style>
-  .title {
+  .content-box.title {
     background: var(--pink);
     color: var(--red);
     margin-bottom: 0;


### PR DESCRIPTION
The styles for the title where overridden by content-box styles.